### PR TITLE
Set a default fsType

### DIFF
--- a/conf/csi-sanlock-lvm-storageclass.yaml
+++ b/conf/csi-sanlock-lvm-storageclass.yaml
@@ -23,6 +23,7 @@ provisioner: csi-sanlock-lvm.csi.vleo.net
 parameters:
   # Default volume group to use.
   volumeGroup: vg01
+  fsType: ext4
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 allowVolumeExpansion: true


### PR DESCRIPTION

Adding an explicit fsType to the sample StorageClass.  Why do this when ext4 is already the default?  With the default [fsGroupPolicy](https://kubernetes-csi.github.io/docs/support-fsgroup.html) of `ReadWriteOnceWithFSType`, `fsGroup` only takes effect on a writeable volume where `fsType` is set explicitly.  Without this change, non-root containers can't use newly-provisioned volumes, since the newly-created filesystem can only be written by root.

Since `ext4` is the default `fsType` anyway, this change should be a noop unless `fsGroup` is specified in the volume manifest.