### PR TITLE
[PoC] ReadWriteMany support

### DIFF
--- a/examples/pvc-block.yaml
+++ b/examples/pvc-block.yaml
@@ -18,7 +18,7 @@ metadata:
   name: test-block-pvc
 spec:
   accessModes:
-  - ReadWriteOnce
+  - ReadWriteMany
   volumeMode: Block
   resources:
     requests:

--- a/pkg/driverd/diskrpcservice.go
+++ b/pkg/driverd/diskrpcservice.go
@@ -50,7 +50,7 @@ type volumeLockerAdapter struct {
 
 func (vl *volumeLockerAdapter) Lock() {
 	for delay := 1 * time.Second; ; {
-		err := vl.locker.LockVolume(vl.ctx, vl.vol, diskRpcOp)
+		err := vl.locker.LockVolume(vl.ctx, vl.vol, false, diskRpcOp)
 		if err == nil {
 			return
 		}

--- a/pkg/driverd/nodeserver.go
+++ b/pkg/driverd/nodeserver.go
@@ -206,8 +206,16 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, status.Errorf(codes.InvalidArgument, "invalid volume id: %v", err)
 	}
 
+	// Use shared mode
+	shared := false
+	if req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER ||
+		req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY ||
+		req.VolumeCapability.AccessMode.Mode == csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER {
+		shared = true
+	}
+
 	// Lock the volume.
-	err = ns.volumeLock.LockVolume(ctx, *vol, defaultLockOp)
+	err = ns.volumeLock.LockVolume(ctx, *vol, shared, defaultLockOp)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is proof-of-concept for [ReadWriteMany support](https://github.com/aleofreddi/csi-sanlock-lvm/issues/44)

The design is simple:
- RWX volumes are openned with shared lock
- Volumes have no owner tags assigned (LVs opened in shared mode do not support assigning tags and actually do not require this owner tag, because it can be assigned to multiple nodes)
- in case of resize we relock volume in exclusive mode, then resize it, then switch back to shared lock.

What tested:
- RWX volumes provisioning (works)
- Attach/detach of block volumes (works)
- KubeVirt live migration (works)
- LiveVolume resizing (works)

What is not tested:
- Creating of snapshots